### PR TITLE
Update README.md to reflect new Texlive version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 ## Features
 
 - Fastest way to code LaTex and produce a pdf file when saving your .tex file
-- Uses [texlive 2020](https://www.tug.org/texlive/acquire-netinstall.html)
+- Uses [texlive 2021](https://www.tug.org/texlive/acquire-netinstall.html)
 - Based on Debian Buster Slim, using [qmcgaw/basedevcontainer](https://github.com/qdm12/basedevcontainer)
 - **Two Docker images**:
     - `qmcgaw/latexdevcontainer:latest` (default) which uses the TexLive basic scheme and has an uncompressed image size of 467MB


### PR DESCRIPTION
Texlive version 2021 is now being used instead of 2020.

Closes https://github.com/qdm12/latexdevcontainer/issues/16