### PR TITLE
Update docker-compose version to fix errors about volumes type

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.2"
 
 services:
   vscode:


### PR DESCRIPTION
Currently, launching the dev container throws an error about 'volumes' not being a string. This version update enables the syntax it should *actually* be using.