### PR TITLE
Updated Text Live Version to 2022

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /tmp/texlive
 ARG SCHEME=scheme-basic
 ARG DOCFILES=0
 ARG SRCFILES=0
-ARG TEXLIVE_VERSION=2021
+ARG TEXLIVE_VERSION=2022
 ARG TEXLIVE_MIRROR=http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends wget gnupg cpanminus && \


### PR DESCRIPTION
This should fix #30 
Only tested local with this command and it worked again:
```
docker buildx build -t qmcgaw/latexdevcontainer:latest-full --build-arg TEXLIVE_VERSION=2022 https://github.com/qdm12/latexdevcontainer.git
```