### PR TITLE
Update to Texlive 2025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ WORKDIR /tmp/texlive
 ARG SCHEME=scheme-basic
 ARG DOCFILES=0
 ARG SRCFILES=0
-ARG TEXLIVE_VERSION=2024
+ARG TEXLIVE_VERSION=2025
 ARG TEXLIVE_MIRROR=http://ctan.math.utah.edu/ctan/tex-archive/systems/texlive/tlnet
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends wget gnupg cpanminus && \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Features
 
 - Fastest way to code LaTex and produce a pdf file when saving your .tex file
-- Uses [texlive 2023](https://www.tug.org/texlive/acquire-netinstall.html)
+- Uses [texlive 2025](https://www.tug.org/texlive/acquire-netinstall.html)
 - Based on Debian Bullseye Slim, using [qmcgaw/basedevcontainer](https://github.com/qdm12/basedevcontainer)
 - Compatible with `amd64` and `aarch64`
 - **Two Docker images**:


### PR DESCRIPTION
Texlive 2025 is now out, meaning tlmgr now shows an error when trying to install/upgrade packages.

I have built this image, pushed to [a Dockerhub fork](https://hub.docker.com/r/skrallex/latexdevcontainer), and tested the container with my own latex document (which requires additional tlmgr package installs).