### PR TITLE
Update tlmgr prior to installing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ texhash
 - You can change the `"postCreateCommand"` to be relevant to your situation. For example:
 
     ```json
-    "postCreateCommand": "tlmgr install acronym pgf && texhash",
+    "postCreateCommand": "tlmgr update --self && tlmgr install acronym pgf && texhash",
     ```
 
 - You can change the extensions installed in the Docker image within the `"customizations/vscode/extensions"` array


### PR DESCRIPTION
The README.md has an example of how to prep the docker image to include custom LaTeX packages using `tlmgr`. Alas, this fails because `tlmgr` needs to update itself before it can install packages